### PR TITLE
cmd/elwin: migrated to viper for config

### DIFF
--- a/cmd/bolt-store/config.toml
+++ b/cmd/bolt-store/config.toml
@@ -1,0 +1,3 @@
+db_file = "test.db"
+listen_address = ":8080"
+metrics_address = ":8081"

--- a/cmd/elwin/config.toml
+++ b/cmd/elwin/config.toml
@@ -1,0 +1,11 @@
+storage_address = ":8080"
+storage_environment = "dev"
+
+json_address = ":8082"
+grpc_address = ":8083"
+update_interval = "10s"
+
+read_timeout = "5s"
+write_timeout = "5s"
+idle_timeout = "30s"
+update_fail_timeout = "5m"


### PR DESCRIPTION
The configuration for elwin was previously only available through
environment variables. This meant that you had to know the environment
variables in order to properly configure elwin. Now you can use a file
of environment variables via the viper library. viper will search for
the file first in the current working directory, then in /etc/elwin.